### PR TITLE
docs: Adjust the Playlist developer documentation

### DIFF
--- a/docs/sources/developers/http_api/playlist.md
+++ b/docs/sources/developers/http_api/playlist.md
@@ -148,7 +148,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
     "interval": "5m",
     "items": [
       {
-        "type": "dashboard_by_id",
+        "type": "dashboard_by_uid",
         "value": "3",
         "order": 1,
         "title":"my third dashboard"
@@ -192,7 +192,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
     "items": [
       {
         "playlistUid": "1",
-        "type": "dashboard_by_id",
+        "type": "dashboard_by_uid",
         "value": "3",
         "order": 1,
         "title":"my third dashboard"
@@ -221,7 +221,7 @@ Content-Type: application/json
     {
       "id": 1,
       "playlistUid": "1",
-      "type": "dashboard_by_id",
+      "type": "dashboard_by_uid",
       "value": "3",
       "order": 1,
       "title":"my third dashboard"


### PR DESCRIPTION
**What is this feature?**

Update the documentation and adjust the create and update part of the playlist. I think, `dashboard_by_id` filter option is not available anymore inside newer Grafana instances.

**Why do we need this feature?**

Good documentation is necessary to call the API correctly.

**Who is this feature for?**

For all people who use the Grafana playlist API.

**Labels and Milestones:**
I'm an external contributor, so, it's not possible to add any related labels or milestones, but I would suggest porting the documentation change back.

backport v11.1.0
no-changelog

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/#how-to-determine-if-content-belongs-in-a-whats-new-document), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/writing-guide/contribute-release-notes/) doc.